### PR TITLE
Error ortográfico challenge README.es.md

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -19,7 +19,7 @@ Este es el repositorio que debes abrir:
 https://github.com/breatheco-de/exercise-postcard
 ```
 
-**👉 Sigue las siguientes instrucciones sobre** [cómo empezar un proyecto nuevo](https://4geeks.com/es/lesson/como-comenzar-un-proyecto-de-codificacion). Importante --> Éste repositorio no es un template.
+**👉 Sigue las siguientes instrucciones sobre** [cómo empezar un proyecto nuevo](https://4geeks.com/es/lesson/como-comenzar-un-proyecto-de-codificacion). Importante --> Este repositorio no es un template.
 
 </onlyfor>
 


### PR DESCRIPTION
Desde hace tiempo, la RAE eliminó la obligatoriedad de la tilde en los demostrativos (este, esta, estos, estas) y también en "solo" cuando no hay riesgo de ambigüedad