### PR TITLE
Update node and learnpack version in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Node.js",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/javascript-node:0-16",
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:22",
 	"customizations": {
 		"vscode": {
 			"settings": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,7 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 
-	"onCreateCommand": "npm i jest@29.7.0 jest-environment-jsdom@29.7.0 -g && npm i @learnpack/learnpack@5.0.13 -g && learnpack plugins:install @learnpack/node@1.1.12 && learnpack plugins:install @learnpack/html@1.1.7"
+	"onCreateCommand": "npm i jest@29.7.0 jest-environment-jsdom@29.7.0 -g && npm i @learnpack/learnpack@5.0.348 -g && learnpack plugins:install @learnpack/node@1.1.12 && learnpack plugins:install @learnpack/html@1.1.7"
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "yarn install",


### PR DESCRIPTION
## Situación
La versión de Learnpack que tenía este paquete (5.0.13) producía logs de error en la terminal del estilo:
`Language en not found for exercise 03-add-first-html, switching to default language`

Si bien son solo warnings, son de color rojo y se producen cada vez que el alumno navega a una nueva lección. Y siendo este el primer proyecto que los alumnos hacen en el prework, esos mensajes de error en la terminal pueden causar confusión.

## Solución
Actualizar la versión de `learnpack` a la versión actual que ya no produce esos warnings.
⚠️ Pero para poder actualizar `learnpack` a su versión actual, es necesario utilizar `node` 22.12+

**Versiones configuradas**:
- learnpack `v5.0.348`
- node `v22.22.2`

✅ Luego de los cambios probé realizar el tutorial de principio a fin y funcionó correctamente.


